### PR TITLE
Add Player Pickups

### DIFF
--- a/scenes/PickupItem03.tscn
+++ b/scenes/PickupItem03.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://scripts/PickupItem03.gd" type="Script" id=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 32, 32 )
+
+[node name="Item3" type="Node2D"]
+script = ExtResource( 2 )
+
+[node name="TestPickup" type="Sprite" parent="."]
+texture = ExtResource( 1 )
+
+[node name="PickupArea3" type="Area2D" parent="TestPickup"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="TestPickup/PickupArea3"]
+shape = SubResource( 1 )
+
+[node name="DurationTimer" type="Timer" parent="."]
+one_shot = true
+[connection signal="body_entered" from="TestPickup/PickupArea3" to="." method="_on_PickupArea3_body_entered"]
+[connection signal="timeout" from="DurationTimer" to="." method="_on_DurationTimer_timeout"]

--- a/scenes/PickupItem04.tscn
+++ b/scenes/PickupItem04.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://scripts/PickupItem04.gd" type="Script" id=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 32, 32 )
+
+[node name="Item4" type="Node2D"]
+script = ExtResource( 2 )
+
+[node name="TestPickup" type="Sprite" parent="."]
+texture = ExtResource( 1 )
+
+[node name="PickupArea4" type="Area2D" parent="TestPickup"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="TestPickup/PickupArea4"]
+shape = SubResource( 1 )
+
+[node name="DurationTimer" type="Timer" parent="."]
+one_shot = true
+[connection signal="body_entered" from="TestPickup/PickupArea4" to="." method="_on_PickupArea4_body_entered"]
+[connection signal="timeout" from="DurationTimer" to="." method="_on_DurationTimer_timeout"]

--- a/scenes/PickupItem05.tscn
+++ b/scenes/PickupItem05.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://scripts/PickupItem05.gd" type="Script" id=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 32, 32 )
+
+[node name="Item5" type="Node2D"]
+script = ExtResource( 2 )
+
+[node name="TestPickup" type="Sprite" parent="."]
+texture = ExtResource( 1 )
+
+[node name="PickupArea5" type="Area2D" parent="TestPickup"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="TestPickup/PickupArea5"]
+shape = SubResource( 1 )
+
+[node name="DurationTimer" type="Timer" parent="."]
+one_shot = true
+[connection signal="body_entered" from="TestPickup/PickupArea5" to="." method="_on_PickupArea5_body_entered"]
+[connection signal="timeout" from="DurationTimer" to="." method="_on_DurationTimer_timeout"]

--- a/scenes/Tutorial.tscn
+++ b/scenes/Tutorial.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=2]
+[gd_scene load_steps=18 format=2]
 
 [ext_resource path="res://assets/art/black.png" type="Texture" id=1]
 [ext_resource path="res://assets/fonts/FFFFORWA.TTF" type="DynamicFontData" id=2]
@@ -13,6 +13,7 @@
 [ext_resource path="res://assets/fonts/FFFFORWA.tres" type="DynamicFont" id=11]
 [ext_resource path="res://scenes/PickupItem03.tscn" type="PackedScene" id=12]
 [ext_resource path="res://scripts/Score.gd" type="Script" id=13]
+[ext_resource path="res://scenes/PickupItem04.tscn" type="PackedScene" id=14]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.203922, 0.388235, 1, 1 )
@@ -119,10 +120,14 @@ one_shot = true
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 
-[node name="Item1" parent="." instance=ExtResource( 8 )]
+[node name="Item1" parent="." groups=[
+"Pickups",
+] instance=ExtResource( 8 )]
 position = Vector2( 880, 880 )
 
-[node name="Item2" parent="." instance=ExtResource( 5 )]
+[node name="Item2" parent="." groups=[
+"Pickups",
+] instance=ExtResource( 5 )]
 position = Vector2( 696, 920 )
 
 [node name="Darkness" parent="." instance=ExtResource( 9 )]
@@ -149,8 +154,17 @@ visible = false
 [node name="ExitButton" parent="GUI" index="2"]
 visible = false
 
-[node name="Item3" parent="." instance=ExtResource( 12 )]
+[node name="Item3" parent="." groups=[
+"Pickups",
+"Resettable Pickups",
+] instance=ExtResource( 12 )]
 position = Vector2( 569.401, 952 )
+
+[node name="Item4" parent="." groups=[
+"Pickups",
+"Resettable Pickups",
+] instance=ExtResource( 14 )]
+position = Vector2( 1008, 848 )
 [connection signal="Dead" from="Player" to="." method="_on_Player_Dead"]
 [connection signal="Dead_Fall" from="Player" to="." method="_on_Player_Dead_Fall"]
 [connection signal="Dead_Suffocate" from="Player" to="." method="_on_Player_Dead_Suffocate"]

--- a/scenes/Tutorial.tscn
+++ b/scenes/Tutorial.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://assets/art/black.png" type="Texture" id=1]
 [ext_resource path="res://assets/fonts/FFFFORWA.TTF" type="DynamicFontData" id=2]
@@ -14,6 +14,7 @@
 [ext_resource path="res://scenes/PickupItem03.tscn" type="PackedScene" id=12]
 [ext_resource path="res://scripts/Score.gd" type="Script" id=13]
 [ext_resource path="res://scenes/PickupItem04.tscn" type="PackedScene" id=14]
+[ext_resource path="res://scenes/PickupItem05.tscn" type="PackedScene" id=15]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.203922, 0.388235, 1, 1 )
@@ -165,6 +166,11 @@ position = Vector2( 569.401, 952 )
 "Resettable Pickups",
 ] instance=ExtResource( 14 )]
 position = Vector2( 1008, 848 )
+
+[node name="Item5" parent="." groups=[
+"Resettable Pickups",
+] instance=ExtResource( 15 )]
+position = Vector2( 1166.66, 952 )
 [connection signal="Dead" from="Player" to="." method="_on_Player_Dead"]
 [connection signal="Dead_Fall" from="Player" to="." method="_on_Player_Dead_Fall"]
 [connection signal="Dead_Suffocate" from="Player" to="." method="_on_Player_Dead_Suffocate"]

--- a/scenes/Tutorial.tscn
+++ b/scenes/Tutorial.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://assets/art/black.png" type="Texture" id=1]
 [ext_resource path="res://assets/fonts/FFFFORWA.TTF" type="DynamicFontData" id=2]
@@ -11,6 +11,8 @@
 [ext_resource path="res://scenes/Darkness.tscn" type="PackedScene" id=9]
 [ext_resource path="res://assets/art/tilesets/tiles.tres" type="TileSet" id=10]
 [ext_resource path="res://assets/fonts/FFFFORWA.tres" type="DynamicFont" id=11]
+[ext_resource path="res://scenes/PickupItem03.tscn" type="PackedScene" id=12]
+[ext_resource path="res://scripts/Score.gd" type="Script" id=13]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.203922, 0.388235, 1, 1 )
@@ -77,6 +79,7 @@ custom_fonts/font = ExtResource( 11 )
 text = "0"
 align = 1
 valign = 1
+script = ExtResource( 13 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -145,7 +148,12 @@ visible = false
 
 [node name="ExitButton" parent="GUI" index="2"]
 visible = false
+
+[node name="Item3" parent="." instance=ExtResource( 12 )]
+position = Vector2( 569.401, 952 )
 [connection signal="Dead" from="Player" to="." method="_on_Player_Dead"]
+[connection signal="Dead_Fall" from="Player" to="." method="_on_Player_Dead_Fall"]
+[connection signal="Dead_Suffocate" from="Player" to="." method="_on_Player_Dead_Suffocate"]
 [connection signal="screen_exited" from="Player/VisibilityNotifier2D" to="Player" method="_on_VisibilityNotifier2D_screen_exited"]
 [connection signal="timeout" from="CanvasLayer/Oxygen/OxygenTimer" to="." method="_on_OxygenTimer_timeout"]
 [connection signal="DamageArea_PlayerCollision" from="Darkness" to="Player" method="_on_Darkness_DamageArea_PlayerCollision"]

--- a/scripts/GUI.gd
+++ b/scripts/GUI.gd
@@ -14,15 +14,24 @@ func game_lose():
 	pass
 
 # Updates the Score label for the Player
-func update_score(score):
+#func update_score(score):
 	#get_node("/root/Main/Player/Camera2D/Score").text = str(score)
 	#get_node("/root/Main/Player/Camera2D/Score").text = str(score)
-	get_node("/root/Tutorial/CanvasLayer/Score").text = str(score)
+#	get_node("/root/Tutorial/CanvasLayer/Score").text = str(score)
 
 # Shows the 'Game Over' screen
 func show_game_over():
 	show_message("Game Over!")
 	$RetryButton.show()
+
+func suffocate():
+	show_message("Game Over!\nYou've Suffocated!")
+	$RetryButton.show()
+
+func fall_off():
+	show_message("Game Over!\nYou've fallen off the map!")
+	$RetryButton.show()
+
 
 
 # Change scene to Tutorial level to start the game

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -29,6 +29,7 @@ func new_game():
 	score = 0
 	darkness.reset()
 	$Player.reset()
+	$Item3.reset()
 	$Player.show()
 	$CanvasLayer/Score.show()
 	$CanvasLayer/PauseScene.show()
@@ -41,7 +42,7 @@ func new_game():
 	# darkness again, otherwise we get collisions causing invalid player death.
 	yield(get_tree().create_timer(1.0), "timeout")
 	darkness.start()
-	$GUI.update_score(score)
+	$CanvasLayer/Score.update_score(score)
 	#$Music.play()
 
 func game_over():
@@ -49,6 +50,14 @@ func game_over():
 	darkness.pause()
 	$GUI.show_game_over()
 	#$Music.stop()
+
+func game_over_oxygen():
+	darkness.pause()
+	$GUI.suffocate()
+
+func game_over_fall():
+	darkness.pause()
+	$GUI.fall_off()
 
 # Once OxygenTimer runs out, the Player's oxygen
 # effectively expires, which kills the Player.
@@ -60,3 +69,11 @@ func _on_OxygenTimer_timeout():
 
 func _on_Player_Dead():
 	game_over()
+
+
+func _on_Player_Dead_Fall():
+	game_over_fall()
+
+
+func _on_Player_Dead_Suffocate():
+	game_over_oxygen()

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -29,7 +29,8 @@ func new_game():
 	score = 0
 	darkness.reset()
 	$Player.reset()
-	$Item3.reset()
+	get_tree().call_group("Resettable Pickups", "reset")
+	#$Item3.reset()
 	$Player.show()
 	$CanvasLayer/Score.show()
 	$CanvasLayer/PauseScene.show()

--- a/scripts/PickupItem03.gd
+++ b/scripts/PickupItem03.gd
@@ -1,0 +1,47 @@
+extends Node2D
+
+var start_score = 0
+var score = start_score
+
+func on_pickup():
+	var main = self.get_parent()
+	for child in main.get_children():
+		if child.name == "Player":
+			$DurationTimer.wait_time = 5
+			$DurationTimer.start()
+			child.movement_speed = 200
+		else:
+			pass
+	pass
+
+func on_Timeout():
+	var main = self.get_parent()
+	for child in main.get_children():
+		if child.name == "Player":
+			if child.movement_speed != 100:
+				child.movement_speed = 100
+			else:
+				pass
+		else:
+			pass
+	pass
+
+func reset():
+	score = start_score
+
+
+func _on_PickupArea3_body_entered(KinematicBody2D):
+	var parent = self.get_parent()
+	for node in parent.get_children():
+		if node.name == "CanvasLayer":
+			if node.get_child(0).name == "Score":
+				score += 100
+				node.get_child(0).update_score(score)
+		else:
+			pass
+	on_pickup()
+	#hide() # Replace with function body.
+
+
+func _on_DurationTimer_timeout():
+	on_Timeout()

--- a/scripts/PickupItem04.gd
+++ b/scripts/PickupItem04.gd
@@ -9,7 +9,7 @@ func on_pickup():
 		if child.name == "Player":
 			$DurationTimer.wait_time = 5
 			$DurationTimer.start()
-			child.movement_speed = 200
+			child.set_health(1000)
 		else:
 			pass
 	pass
@@ -18,8 +18,8 @@ func on_Timeout():
 	var main = self.get_parent()
 	for child in main.get_children():
 		if child.name == "Player":
-			if child.movement_speed != 100:
-				child.movement_speed = 100
+			if child.check_health() > 100:
+				child.set_health(100)
 			else:
 				pass
 		else:
@@ -30,7 +30,7 @@ func reset():
 	score = start_score
 
 
-func _on_PickupArea3_body_entered(KinematicBody2D):
+func _on_PickupArea4_body_entered(KinematicBody2D):
 	var parent = self.get_parent()
 	for node in parent.get_children():
 		if node.name == "CanvasLayer":
@@ -48,6 +48,7 @@ func _on_PickupArea3_body_entered(KinematicBody2D):
 #					node.get_child(0).update_score(new_score)
 				else:
 					pass
+				
 		else:
 			pass
 	on_pickup()

--- a/scripts/PickupItem05.gd
+++ b/scripts/PickupItem05.gd
@@ -1,0 +1,48 @@
+extends Node2D
+
+var start_score = 0
+var score = start_score
+
+func on_pickup():
+	var main = self.get_parent()
+	main.oxygen_timer.stop()
+	main.oxygen_bar.value = main.oxygen_bar.max_value
+	$DurationTimer.wait_time = 5
+	$DurationTimer.start()
+
+func on_Timeout():
+	var main = self.get_parent()
+	main.oxygen_timer.start()
+	main.oxygen_bar.value = main.oxygen_timer.time_left
+
+func reset():
+	score = start_score
+
+
+func _on_PickupArea5_body_entered(KinematicBody2D):
+	var parent = self.get_parent()
+	for node in parent.get_children():
+		if node.name == "CanvasLayer":
+			if node.get_child(0).name == "Score":
+				score = node.get_child(0).check_score()
+				var new_score = start_score + 100
+				if score >= new_score or score <= new_score:
+					new_score = score + 100
+					node.get_child(0).update_score(new_score)
+#				elif score > new_score:
+#					new_score == score + 100
+#					node.get_child(0).update_score(new_score)
+#				elif score < new_score:
+#					new_score == score + 100
+#					node.get_child(0).update_score(new_score)
+				else:
+					pass
+				
+		else:
+			pass
+	on_pickup()
+	#hide() # Replace with function body.
+
+
+func _on_DurationTimer_timeout():
+	on_Timeout()

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -70,6 +70,14 @@ func player_heal(amount):
 	else:
 		pass
 
+# Sets health value to specific amount
+func set_health(amount):
+	self.health = amount
+
+# Checks and returns current player health value
+func check_health():
+	return self.health
+
 # Main player oxygen function
 func player_oxygen(amount, empty = false):
 	if oxygen != max_oxygen:

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -90,6 +90,14 @@ func player_oxygen(amount, empty = false):
 	else:
 		pass
 
+# Sets oxygen value to specific amount
+func set_oxygen(amount):
+	self.oxygen = amount
+
+# Checks and returns current player oxygen value
+func check_oxygen():
+	return self.oxygen
+
 func _physics_process(delta):
 	if alive: # Only create velocity when player is alive
 		get_input()

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -1,6 +1,8 @@
 extends KinematicBody2D
 
 signal Dead()
+signal Dead_Suffocate()
+signal Dead_Fall()
 
 export (int) var movement_speed = 100
 export (int) var gravity = 1200
@@ -33,6 +35,7 @@ func reset():
 	self.position.y = origin.y
 	health = max_health
 	oxygen = max_oxygen
+	movement_speed = 100
 	alive = true
 
 # Main Player movement
@@ -108,8 +111,15 @@ func _on_Darkness_DamageArea_PlayerCollision():
 
 # Main Player death function
 func _die():
-	alive = false
-	emit_signal("Dead")
+	if oxygen <= 0:
+		alive = false
+		emit_signal("Dead_Suffocate")
+	elif $VisibilityNotifier2D.is_on_screen() == false:
+		alive = false
+		emit_signal("Dead_Fall")
+	else:
+		alive = false
+		emit_signal("Dead")
 
 
 func _on_VisibilityNotifier2D_screen_exited():

--- a/scripts/Score.gd
+++ b/scripts/Score.gd
@@ -1,6 +1,10 @@
 extends Label
 
 
+func check_score():
+	#print(int(self.text))
+	return int(self.text)
+
 func update_score(score):
 	self.text = str(score)
 

--- a/scripts/Score.gd
+++ b/scripts/Score.gd
@@ -2,4 +2,18 @@ extends Label
 
 
 func update_score(score):
-	get_node("/root/Player/HUD/Score").text = str(score)
+	self.text = str(score)
+
+
+#	var tutorial = self.get_parent()
+#	if tutorial.name == "Tutorial":
+#		for child in tutorial.get_children():
+#			if child.name == "CanvasLayer":
+#				if child.get_child(0).name == "Score":
+#					child.text = str(score)
+#				else:
+#					pass
+#	else:
+#		pass
+	
+	#get_node("/root/Player/HUD/Score").text = str(score)


### PR DESCRIPTION
# Description

This PR adds the needed player pickups, which also increase score on player collision.

## Fixes [$121](https://open.codecks.io/lunarun/decks/5-code/card/121-create-item-pickup-on-player-collision)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

For code changes:

- [X] I have performed a self-review of my own code and have established there are no errors.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.