### PR TITLE
Make Trader Interactable

### DIFF
--- a/assets/fonts/Trader_Chat_Font.tres
+++ b/assets/fonts/Trader_Chat_Font.tres
@@ -1,0 +1,7 @@
+[gd_resource type="DynamicFont" load_steps=2 format=2]
+
+[ext_resource path="res://assets/fonts/FFFFORWA.TTF" type="DynamicFontData" id=1]
+
+[resource]
+use_mipmaps = true
+font_data = ExtResource( 1 )

--- a/scenes/Trader.tscn
+++ b/scenes/Trader.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://assets/art/characters/player.png" type="Texture" id=1]
+[ext_resource path="res://scripts/Trader/Trader_StaticBody.gd" type="Script" id=3]
+
+[sub_resource type="CapsuleShape2D" id=1]
+radius = 7.75
+height = 8.25
+
+[node name="Trader" type="Node2D"]
+
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
+input_pickable = true
+script = ExtResource( 3 )
+
+[node name="Sprite" type="Sprite" parent="StaticBody2D"]
+texture = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
+position = Vector2( -2.5, 2 )
+shape = SubResource( 1 )

--- a/scenes/Trader.tscn
+++ b/scenes/Trader.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://assets/art/characters/player.png" type="Texture" id=1]
+[ext_resource path="res://assets/fonts/Trader_Chat_Font.tres" type="DynamicFont" id=2]
 [ext_resource path="res://scripts/Trader/Trader_StaticBody.gd" type="Script" id=3]
 
 [sub_resource type="CapsuleShape2D" id=1]
@@ -9,13 +10,31 @@ height = 8.25
 
 [node name="Trader" type="Node2D"]
 
-[node name="StaticBody2D" type="StaticBody2D" parent="."]
-input_pickable = true
+[node name="Area2D" type="Area2D" parent="."]
+position = Vector2( 970.151, 497.803 )
+scale = Vector2( 4, 4 )
 script = ExtResource( 3 )
 
-[node name="Sprite" type="Sprite" parent="StaticBody2D"]
+[node name="Sprite" type="Sprite" parent="Area2D"]
 texture = ExtResource( 1 )
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 position = Vector2( -2.5, 2 )
 shape = SubResource( 1 )
+
+[node name="TraderChat" type="Label" parent="."]
+visible = false
+margin_left = 906.151
+margin_top = 419.803
+margin_right = 998.151
+margin_bottom = 441.803
+custom_fonts/font = ExtResource( 2 )
+align = 1
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ChatTimer" type="Timer" parent="TraderChat"]
+one_shot = true
+[connection signal="timeout" from="TraderChat/ChatTimer" to="Area2D" method="_on_ChatTimer_timeout"]

--- a/scripts/Trader/Trader_StaticBody.gd
+++ b/scripts/Trader/Trader_StaticBody.gd
@@ -1,0 +1,16 @@
+extends StaticBody2D
+
+var is_clicked = false
+
+func _input_event(viewport, event, shape_idx):
+	if event is InputEventMouseButton:
+		is_clicked = event.pressed
+
+func _process(delta):
+	if Input.is_mouse_button_pressed(BUTTON_RIGHT) and is_clicked:
+		# Open Inventory
+		reply()
+
+func reply():
+	# Add actual reply as a label
+	print("Stop clicking on me! :(")

--- a/scripts/Trader/Trader_StaticBody.gd
+++ b/scripts/Trader/Trader_StaticBody.gd
@@ -1,16 +1,28 @@
-extends StaticBody2D
+extends Area2D
 
 var is_clicked = false
+onready var t_chat = get_parent().get_node("TraderChat")
+onready var chat_timer = get_parent().get_node("TraderChat/ChatTimer")
 
 func _input_event(viewport, event, shape_idx):
-	if event is InputEventMouseButton:
-		is_clicked = event.pressed
+	if event is InputEventMouseButton \
+	and event.button_index == BUTTON_RIGHT \
+	and event.is_pressed():
+		self.on_click()
 
-func _process(delta):
-	if Input.is_mouse_button_pressed(BUTTON_RIGHT) and is_clicked:
-		# Open Inventory
-		reply()
+func on_click():
+	print("Click")
+	reply()
 
 func reply():
 	# Add actual reply as a label
-	print("Stop clicking on me! :(")
+	var replies = ["What're you buyin'?", "...", "You need something?", 
+	"I'm coded so well"]
+	randomize()
+	t_chat.show()
+	t_chat.text = replies[randi()%replies.size()]
+	chat_timer.wait_time = 5
+	chat_timer.start()
+
+func _on_ChatTimer_timeout():
+	t_chat.hide()


### PR DESCRIPTION
# Description

This PR adds a Trader scene and makes the 'Trader' interactable.
Specifically, when the Player **right clicks** on the 'Trader', he 'replies' with a random line from an array.

This should be expanded on by making the Trader present his inventory to the Player on click.

## Fixes [$12c](https://chaotic-games420.codecks.io/card/12c-make-trader-interactable)

## Type of change

Delete options that are not relevant to your change/addition.

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

For code changes:

- [X] My code follows the style guidelines ([PEP 8](https://pep8.org/)) of this project.
- [X] I have performed a self-review of my own code and have established there are no errors.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.